### PR TITLE
Add trim function

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Remove subtitles
 $subtitles->remove(0, 5); // from 0, till 5 seconds
 ```
 
+Trim subtitles
+```php
+$subtitles->trim(3, 4); // get only from 3, till 4 seconds
+```
+
 Add 1 second to all subtitles
 ```php
 $subtitles->shiftTime(1);

--- a/src/Subtitles.php
+++ b/src/Subtitles.php
@@ -1,7 +1,7 @@
 <?php namespace Done\Subtitles;
 
-interface SubtitleContract {
-
+interface SubtitleContract
+{
     public static function convert($from_file_path, $to_file_path);
 
     public static function load($file_name_or_file_content, $extension = null); // load file
@@ -18,8 +18,8 @@ interface SubtitleContract {
 }
 
 
-class Subtitles implements SubtitleContract {
-
+class Subtitles implements SubtitleContract
+{
     protected $input;
     protected $input_format;
 
@@ -63,6 +63,14 @@ class Subtitles implements SubtitleContract {
         ];
 
         $this->sortInternalFormat();
+
+        return $this;
+    }
+
+    public function trim($startTime, $endTime)
+    {
+        $this->remove('0', $startTime);
+        $this->remove($endTime, $this->maxTime());
 
         return $this;
     }
@@ -149,7 +157,7 @@ class Subtitles implements SubtitleContract {
 
     protected function sortInternalFormat()
     {
-        usort($this->internal_format, function($item1, $item2) {
+        usort($this->internal_format, function ($item1, $item2) {
             if ($item2['start'] == $item1['start']) {
                 return 0;
             } elseif ($item2['start'] < $item1['start']) {
@@ -172,7 +180,8 @@ class Subtitles implements SubtitleContract {
         return $max_time;
     }
 
-    protected function shouldBlockBeRemoved($block, $from, $till) {
+    protected function shouldBlockBeRemoved($block, $from, $till)
+    {
         return ($from < $block['start'] && $block['start'] < $till) || ($from < $block['end'] && $block['end'] < $till);
     }
 

--- a/tests/PublicInterfaceTest.php
+++ b/tests/PublicInterfaceTest.php
@@ -3,8 +3,8 @@
 use PHPUnit\Framework\TestCase;
 use Done\Subtitles\Subtitles;
 
-class PublicInterfaceTest extends TestCase {
-
+class PublicInterfaceTest extends TestCase
+{
     use AdditionalAssertions;
 
     public function testConvert()
@@ -90,7 +90,6 @@ our final approach into Coruscant.
 
         $srt_path = './tests/files/srt_for_public_interface_test.srt';
         Subtitles::load($srt_path)->content('exe');
-
     }
 
     public function testAdd()
@@ -279,6 +278,23 @@ our final approach into Coruscant.
 
     // ------------------------------------ shiftTimeGradually ---------------------------------------------------------
 
+    public function testTrim()
+    {
+        $actual_internal_format = (new Subtitles())
+            ->add(0, 2, 'a')
+            ->add(2, 4, 'b')
+            ->add(4, 6, 'c')
+            ->add(6, 8, 'd')
+            ->add(8, 10, 'e')
+            ->trim(4, 8)
+            ->getInternalFormat();
 
+        $expected_internal_format = (new Subtitles())
+             ->add(4, 6, 'c')
+            ->add(6, 8, 'd')
+            ->add(8, 10, 'e')
+            ->getInternalFormat();
 
+        $this->assertInternalFormatsEqual($expected_internal_format, $actual_internal_format);
+    }
 }


### PR DESCRIPTION
# About
This PR is for adding a `trim` function that only gets the range from `startTime` till `endTime`. It reuses the `remove` function under the hood.

# Changes
A `trim` function has been added on the `Subtitles.php`
A new test called `testTrim` has been added to assert actual and expected `internal_format`
Readme has been added to add details of the new function

